### PR TITLE
Add on  callback to show message on build finish

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 var gulp = require('gulp');
 var browserify = require('browserify');
 var source = require('vinyl-source-stream');
-var buffer = require('vinyl-buffer')
+var buffer = require('vinyl-buffer');
 var uglify = require('gulp-uglify');
 
 gulp.task('build', function (cb) {
@@ -12,5 +12,6 @@ gulp.task('build', function (cb) {
   .pipe(source('main.min.js'))
   .pipe(buffer())
   .pipe(uglify())
-  .pipe(gulp.dest('js'));
-});
+  .pipe(gulp.dest('js'))
+  .on('end', cb);
+})


### PR DESCRIPTION
A message such as `Finished 'build' after 20 ms` is not shown without `cb()` on Gulp stream end, nevertheless the build may be completed. This PR improves messages on shell and enhances usability of this template project.